### PR TITLE
refactor: Rewrite the gradle buildscript, update dependencies and populate fabric.mod.json fields automatically

### DIFF
--- a/1.18/build.gradle
+++ b/1.18/build.gradle
@@ -1,14 +1,16 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
-    id 'maven-publish'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
 }
 
+base {
+    archivesName = project.mod_name.replaceAll("\\s", "-") + "-fabric"
+}
 
 version = project.mod_version
 group = project.maven_group
 
 repositories {
-    maven { url = "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
+    maven { url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
     maven { url "https://maven.shedaniel.me/" }
     maven { url "https://maven.terraformersmc.com/releases/" }
     maven { url "https://maven.parchmentmc.org/" }
@@ -20,25 +22,44 @@ repositories {
 
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
+
     mappings loom.layered() {
         officialMojangMappings()
         parchment("org.parchmentmc.data:parchment-${project.parchment_version}@zip")
     }
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    modImplementation "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}+${project.minecraft_version}"
+
+    // Development dependencies
     modRuntimeOnly "me.djtheredstoner:DevAuth-fabric:${project.devauth_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-    modApi("me.shedaniel.cloth:cloth-config-fabric:10.0.96") {
+
+    // Optional dependencies
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}") {
+        exclude(group: "net.fabricmc.fabric-loader")
         exclude(group: "net.fabricmc.fabric-api")
     }
-    modApi("com.terraformersmc:modmenu:6.1.0") {
+
+    modApi("com.terraformersmc:modmenu:${mod_menu_version}") {
+        exclude(group: "net.fabricmc.fabric-loader")
         exclude(group: "net.fabricmc.fabric-api")
     }
 }
 
 processResources {
-    inputs.property "version", project.version
+    var replaceProperties = [
+            mod_version                : version,
+            mod_id                     : maven_group,
+            mod_name                   : mod_name,
+            minecraft_version          : minecraft_version,
+            fabric_loader_version      : fabric_loader_version,
+            fabric_api_version         : fabric_api_version,
+            cloth_config_version       : cloth_config_version,
+    ]
+    inputs.properties replaceProperties
+
     filesMatching("fabric.mod.json") {
-        expand "version": project.version
+        expand replaceProperties
     }
 }
 
@@ -49,8 +70,10 @@ tasks.withType(JavaCompile).configureEach {
 
 java {
     withSourcesJar()
-}
 
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 
 sourceSets {
     main {
@@ -62,15 +85,6 @@ sourceSets {
 
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}" }
+        rename { "${it}_${base.archivesName}"}
     }
 }
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-}
-

--- a/1.18/gradle.properties
+++ b/1.18/gradle.properties
@@ -1,22 +1,31 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx3G
 
-
 # Fabric Properties
 
-# check these on https://fabricmc.net/develop
+# Check these on https://fabricmc.net/develop
 minecraft_version=1.21
-parchment_version=1.20.6:2024.06.02
-loader_version=0.15.11
+fabric_loader_version=0.15.11
+
+# Check for latest at https://ldtteam.jfrog.io/ui/native/parchmentmc-internal/org/parchmentmc/data
+parchment_version=1.21:2024.07.07
 
 # Mod Properties
 mod_version=1.8.2
 maven_group=wynnvp
-archives_base_name=Voices-of-wynn-fabric
+mod_name=Voices of Wynn
 
 # Dependencies
-fabric_version=0.100.1+1.21
-# --------------------------------------------------------------------------------------------------------------------
-# Mod specific settings
+fabric_api_version=0.100.1
+
+# Cloth Config version
+# Check the latest version on https://maven.shedaniel.me/me/shedaniel/cloth/cloth-config-fabric/
+cloth_config_version=15.0.127
+
+# Mod Menu version
+# Check the latest version on https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu
+mod_menu_version=11.0.1
+
 # DevAuth version
-devauth_version=1.1.0
+# Check the latest version on https://github.com/DJtheRedstoner/DevAuth/releases
+devauth_version=1.2.1

--- a/1.18/src/main/resources/fabric.mod.json
+++ b/1.18/src/main/resources/fabric.mod.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "id": "wynnvp",
-  "version": "${version}",
-  "name": "Voices of wynn",
+  "id": "${mod_id}",
+  "version": "${mod_version}",
+  "name": "${mod_name}",
   "description": "Now fabricated.",
   "authors": [
     "https://voicesofwynn.com/credits"
@@ -27,10 +27,9 @@
     "wynnvp.mixins.json"
   ],
   "depends": {
-    "cloth-config": ">=10.0.96",
-    "fabricloader": ">=0.14.22",
-    "fabric-api": ">=0.78.0",
-    "minecraft": "1.21",
-    "java": ">=17"
+    "cloth-config": ">=${cloth_config_version}",
+    "fabricloader": ">=${fabric_loader_version}",
+    "fabric-api": ">=${fabric_api_version}",
+    "minecraft": "${minecraft_version}"
   }
 }

--- a/1.18/src/main/resources/wynnvp.mixins.json
+++ b/1.18/src/main/resources/wynnvp.mixins.json
@@ -1,6 +1,6 @@
 {
   "required": true,
-  "minVersion": "0.8",
+  "minVersion": "0.8.5",
   "package": "com.wynnvp.wynncraftvp.events.mixins",
   "compatibilityLevel": "JAVA_17",
   "mixins": [],


### PR DESCRIPTION
These changes should make it easier to manage versions in the future. It should also help with issues with the fabric loader being present on the classpath twice in development environment.