### PR TITLE
fix: Don't upload build artifacts

### DIFF
--- a/.github/workflows/format-build.yml
+++ b/.github/workflows/format-build.yml
@@ -50,9 +50,3 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
         with:
           arguments: buildDependents -x spotlessCheck -x test
-
-      - name: Capture Build Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: Artifacts
-          path: build/libs/


### PR DESCRIPTION
Uploading artifacts for a mod this large should not be done once per every PR commit, because it'll take no time to full the monthly (20GB?) quota.