### PR TITLE
feat!: Add automated releases to Github Releases and CurseForge with Github Actions

### DIFF
--- a/.github/.config.js
+++ b/.github/.config.js
@@ -1,0 +1,74 @@
+"use strict";
+const config = require("conventional-changelog-conventionalcommits");
+
+function whatBump(commits) {
+    let releaseType = 2;
+
+    // chore(bump-mc) or chore! -> major (0)
+    // feat! or fix! -> minor (1)
+    // otherwise -> patch (2)
+
+    for (let commit of commits) {
+        if (commit == null || !commit.header) continue;
+
+        // We want to select the highest release type
+        if (commit.header.startsWith("chore(bump-mc)") || commit.header.startsWith("chore!")) {
+            releaseType = 0;
+            break;
+        }
+
+        if ((commit.header.startsWith("feat!") || commit.header.startsWith("fix!")) && releaseType > 1) {
+            releaseType = 1;
+        }
+    }
+
+    let releaseTypes = ["major", "minor", "patch"];
+
+    let reason = "No special commits found. Defaulting to a patch.";
+
+    switch (releaseTypes[releaseType]) {
+        case "major":
+            reason = "Found a commit with a chore(bump-mc) header..";
+            break;
+        case "minor":
+            reason = "Found a commit with a feat! or fix! header.";
+            break;
+    }
+
+    return {
+        releaseType: releaseTypes[releaseType],
+        reason: reason
+    }
+}
+
+async function getOptions() {
+    let options = await config(
+        {
+            types: [
+                // Unhide all types except "ci" so that they show up on generated changelog
+                // Default values:
+                // https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/writer-opts.js
+                { type: "feat", section: "New Features" },
+                { type: "feature", section: "New Features" },
+                { type: "fix", section: "Bug Fixes" },
+                { type: "perf", section: "Performance Improvements" },
+                { type: "revert", section: "Reverts" },
+                { type: "docs", section: "Documentation" },
+                { type: "style", section: "Styles" },
+                { type: "chore", section: "Miscellaneous Chores" },
+                { type: "refactor", section: "Code Refactoring" },
+                { type: "test", section: "Tests" },
+                { type: "build", section: "Build System" },
+                { type: "ci", section: "Continuous Integration", hidden: true },
+            ]
+        }
+    );
+
+    // Both of these are used in different places...
+    options.recommendedBumpOpts.whatBump = whatBump;
+    options.whatBump = whatBump;
+
+    return options;
+}
+
+module.exports = getOptions();

--- a/.github/.pre-commit.js
+++ b/.github/.pre-commit.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+
+exports.preCommit = (props) => {
+    const replace = (path, searchValue, replaceValue) => {
+        let content = fs.readFileSync(path, "utf-8");
+        if (content.match(searchValue)) {
+            fs.writeFileSync(path, content.replace(searchValue, replaceValue));
+            console.log(`"${path}" changed`);
+        }
+    };
+
+    // replace only the version string example:
+    // version = "0.0.3-alpha.2"
+    // version = "0.0.3-alpha.103+MC-1.19.4"
+    replace("./build.gradle", /(?<=version = ")\d+\.\d+\.\d+((-\w+)+\.\d+)?(-SNAPSHOT)?(?=")/g, props.version);
+    // Regex provided by Github Copilot
+};

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,22 @@
+name: Autopromote branches
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-release:
+    if: github.ref == 'refs/heads/main'
+    name: Merge main into release after a release request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: merge
+        uses: mtanzi/action-automerge@v1
+        id: merge
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          source: 'main'
+          target: 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,163 @@
+name: Publish Release
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  changelog:
+    name: Generate Changelog
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.changelog.outputs.tag }}
+      skipped: ${{ steps.changelog.outputs.skipped }}
+      clean_changelog: ${{ steps.changelog.outputs.clean_changelog }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+      - run: |
+          npm install conventional-changelog-conventionalcommits@7.0.2
+          npm install conventional-recommended-bump@9.0.0
+
+      - name: Set up version.json
+        run: echo "{"version":$(git describe --tags --abbrev=0)}" > version.json
+
+      - name: Create changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v5.2.1
+        with:
+          github-token: ${{ secrets.PRIVATE_TOKEN }}
+          git-user-name: 'VoWBot'
+          git-user-email: 'admin@voicesofwynn.com'
+          pre-commit: ./.github/.pre-commit.js
+          config-file-path: ./.github/.config.js
+          version-file: ./version.json
+          skip-version-file: true
+          skip-git-pull: true
+          pre-release: false
+          release-count: 5
+
+      - name: Create release
+        if: ${{ steps.changelog.outputs.skipped != 'true' }}
+        id: release
+        uses: softprops/action-gh-release@v2.0.7
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          draft: true
+          prerelease: false
+
+      - name: Upload version information
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build.gradle
+
+  build:
+    name: Build
+    needs: [changelog] # Build needs the new version number
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4 # Download version information from changelog
+        with:
+          name: build
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: "gradle"
+
+      - name: Build with Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          arguments: buildDependents -x spotlessCheck -x test
+
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: |
+            **/build/libs/*-fabric+MC-*.jar
+          if-no-files-found: error
+          overwrite: true
+
+  release-github:
+    name: Release to Github
+    if: ${{ needs.changelog.outputs.skipped != 'true' }}
+    runs-on: ubuntu-latest
+    needs: [ build, changelog ]
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Create release and upload files
+        if: ${{ needs.changelog.outputs.skipped != 'true' }}
+        id: release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.changelog.outputs.tag }}
+          body: ${{ needs.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
+          files: |
+            **/build/libs/*-fabric+MC-*.jar
+
+      - name: Set current date
+        id: date
+        run: |
+          echo "::set-output name=short::$(date +'%Y-%m-%d')"
+          echo "::set-output name=long::$(date +'%Y-%m-%d %H:%M')"
+
+      - name: Post release on Discord
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          embed-color: "4915330"
+          embed-title: ${{format('Voices of Wynn {0}', needs.changelog.outputs.tag)}}
+          embed-description: ${{ needs.changelog.outputs.changelog }}
+          embed-url: ${{ steps.release.outputs.url }}
+          embed-timestamp: ${{ steps.date.outputs.long }}
+
+  release-external:
+    name: Release to CurseForge
+    if: ${{ needs.changelog.outputs.skipped != 'true' }}
+    strategy:
+      matrix:
+        modloader: [fabric]
+    runs-on: ubuntu-latest
+    needs: [build, changelog]
+    steps:
+      - name: Download build
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          curseforge-id: 857921
+          curseforge-token: ${{ secrets.CF_API_TOKEN }}
+
+          files: "**/build/libs/*-${{ matrix.modloader }}*.jar"
+
+          name: Voices of Wynn (${{ matrix.modloader }}) ${{ needs.changelog.outputs.tag }}
+          version: ${{ needs.changelog.outputs.tag }}
+          version-type: release
+          game-versions: 1.21
+          changelog: ${{ needs.changelog.outputs.changelog }}
+
+          loaders: ${{ matrix.modloader }}
+          java: 21

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,11 @@ base {
     archivesName = project.mod_name.replaceAll("\\s", "-") + "-fabric"
 }
 
-version = project.mod_version
 group = project.maven_group
+
+// On the release branches, this string will be automatically updated by the bots
+// Do not change this in the main branch!
+version = "1.0.0-SNAPSHOT"
 
 repositories {
     maven { url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1" }
@@ -136,6 +139,10 @@ java {
 
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
+}
+
+remapJar {
+    archiveClassifier = "fabric+MC-${minecraft_version}"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ fabric_loader_version=0.15.11
 parchment_version=1.21:2024.07.07
 
 # Mod Properties
-mod_version=1.8.2
 maven_group=wynnvp
 mod_name=Voices of Wynn
 

--- a/src/main/java/com/wynnvp/wynncraftvp/ModCore.java
+++ b/src/main/java/com/wynnvp/wynncraftvp/ModCore.java
@@ -10,18 +10,21 @@ import com.wynnvp.wynncraftvp.logging.VowLogger;
 import com.wynnvp.wynncraftvp.sound.SoundPlayer;
 import com.wynnvp.wynncraftvp.sound.SoundsHandler;
 import com.wynnvp.wynncraftvp.text.ChatHandler3;
+import java.util.Optional;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.SharedConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ModCore implements ModInitializer {
     public static final String MODID = "wynnvp";
-    public static final String NAME = "Wynncraft Voice Project";
-    public static final String VERSION = "1.8.2";
+
+    private String version;
 
     public static boolean inLiveWynnServer = false;
     public static boolean isUsingClothApi = false;
@@ -37,6 +40,19 @@ public class ModCore implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        Optional<ModContainer> vowMod = FabricLoader.getInstance().getModContainer(MODID);
+        if (vowMod.isEmpty()) {
+            ModCore.error("Mod not found by fabric.");
+            return;
+        }
+
+        version = "v" + vowMod.get().getMetadata().getVersion().getFriendlyString();
+
+        LOGGER.info(
+                "Loading Voices of Wynn {} (on Minecraft {})",
+                version,
+                SharedConstants.getCurrentVersion().getName());
+
         Managers.initialize();
 
         instance = this;
@@ -46,15 +62,9 @@ public class ModCore implements ModInitializer {
         soundsHandler = new SoundsHandler();
 
         isUsingClothApi = FabricLoader.getInstance().isModLoaded("cloth-config");
-        //    if (isUsingClothApi) {
-        LOGGER.debug("Found cloth api");
 
         AutoConfig.register(VOWAutoConfig.class, Toml4jConfigSerializer::new);
-
         config = AutoConfig.getConfigHolder(VOWAutoConfig.class).getConfig();
-        /*  } else {
-            config = new VOWAutoConfig();
-        }*/
 
         VowLogger.Initialize();
 
@@ -82,5 +92,9 @@ public class ModCore implements ModInitializer {
 
     public static void info(String msg) {
         LOGGER.info(msg);
+    }
+
+    public String getVersion() {
+        return version;
     }
 }

--- a/src/main/java/com/wynnvp/wynncraftvp/utils/VersionChecker.java
+++ b/src/main/java/com/wynnvp/wynncraftvp/utils/VersionChecker.java
@@ -42,7 +42,8 @@ public class VersionChecker {
             return;
         }
 
-        String version = ModCore.VERSION;
+        // Strip the "v" from the version
+        String version = ModCore.instance.getVersion().substring(1);
 
         float versionInFloat = GetVersionNumberInFloat(version);
         float killSwitchVersionInFloat = GetVersionNumberInFloat(killSwitchVersion);


### PR DESCRIPTION
**Before this is working, a commit needs to be tagged `v1.8.2`.**

Documentation for versioning:
- A normal release bumps the patch version.
- A `feat!` or `fix!` commit bumps the minor version.
- A `chore!` or `chore(bump-mc)` commit bumps the major version.

So the versioning is essentially: `major.minor.patch` -> `MC.MAJORFEAT/FIX.ANYPATCH`.

I've made this PR `feat!` to target a release for `v1.9.0`.