### PR TITLE
feat: Allow VoW to be used with 1.21.1 (along with 1.21)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,8 @@ jobs:
           name: Voices of Wynn (${{ matrix.modloader }}) ${{ needs.changelog.outputs.tag }}
           version: ${{ needs.changelog.outputs.tag }}
           version-type: release
-          game-versions: 1.21
+          game-versions: |
+            >=1.21 <=1.21.1
           changelog: ${{ needs.changelog.outputs.changelog }}
 
           loaders: ${{ matrix.modloader }}

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ processResources {
         mod_version                : version,
         mod_id                     : maven_group,
         mod_name                   : mod_name,
-        minecraft_version          : minecraft_version,
+        minecraft_version_range    : minecraft_version_range,
         fabric_loader_version      : fabric_loader_version,
         fabric_api_version         : fabric_api_version,
         cloth_config_version       : cloth_config_version,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 
 # Check these on https://fabricmc.net/develop
 minecraft_version=1.21
+minecraft_version_range=>=1.21 <=1.21.1
 fabric_loader_version=0.16.0
 
 # Check for latest at https://ldtteam.jfrog.io/ui/native/parchmentmc-internal/org/parchmentmc/data

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,7 +11,7 @@
     "cloth-config": ">=${cloth_config_version}",
     "fabric-api": ">=${fabric_api_version}",
     "fabricloader": ">=${fabric_loader_version}",
-    "minecraft": "${minecraft_version}"
+    "minecraft": "${minecraft_version_range}"
   },
   "description": "Now fabricated.",
   "entrypoints": {


### PR DESCRIPTION
Development stays on 1.21, but since 1.21 and 1.21.1 is the very same version, except a small fix, the mod can be compatible with both versions (as Wynntils is).