### PR TITLE
fix: release being tagged with the wrong minecraft version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           name: Voices of Wynn (${{ matrix.modloader }}) ${{ needs.changelog.outputs.tag }}
           version: ${{ needs.changelog.outputs.tag }}
           version-type: release
-          game-versions: 1.21.4
+          game-versions: 1.21.11
           changelog: ${{ needs.changelog.outputs.changelog }}
 
           loaders: ${{ matrix.modloader }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated target game version for external releases to 1.21.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->