### PR TITLE
fix: Add step to startup to clean up corrupt config file which if corrupt caused crashes

### DIFF
--- a/src/main/java/com/wynnvp/wynncraftvp/ModCore.java
+++ b/src/main/java/com/wynnvp/wynncraftvp/ModCore.java
@@ -6,6 +6,7 @@ package com.wynnvp.wynncraftvp;
 
 import com.wynnvp.wynncraftvp.commands.DebugCommand;
 import com.wynnvp.wynncraftvp.commands.VowLogCommand;
+import com.wynnvp.wynncraftvp.config.ConfigFileRecovery;
 import com.wynnvp.wynncraftvp.config.VOWAutoConfig;
 import com.wynnvp.wynncraftvp.core.Managers;
 import com.wynnvp.wynncraftvp.logging.VowLogger;
@@ -15,6 +16,8 @@ import com.wynnvp.wynncraftvp.sound.downloader.AudioDownloader;
 import com.wynnvp.wynncraftvp.sound.downloader.ToastManager;
 import com.wynnvp.wynncraftvp.sound.player.AudioPlayer;
 import com.wynnvp.wynncraftvp.text.OverlayHandler;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
@@ -69,6 +72,7 @@ public class ModCore implements ModInitializer {
 
         isUsingClothApi = FabricLoader.getInstance().isModLoaded("cloth-config");
 
+        recoverCorruptedConfig();
         AutoConfig.register(VOWAutoConfig.class, Toml4jConfigSerializer::new);
         config = AutoConfig.getConfigHolder(VOWAutoConfig.class).getConfig();
 
@@ -115,5 +119,18 @@ public class ModCore implements ModInitializer {
 
     public String getVersion() {
         return version;
+    }
+
+    private static void recoverCorruptedConfig() {
+        Path configPath = FabricLoader.getInstance().getConfigDir().resolve(MODID + ".toml");
+        try {
+            if (ConfigFileRecovery.quarantineIfNullByteCorrupted(configPath)) {
+                LOGGER.warn(
+                        "Found a corrupted Voices of Wynn config at {} and moved it aside. A new default config will be created.",
+                        configPath);
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Failed to check Voices of Wynn config for corruption before loading it.", e);
+        }
     }
 }

--- a/src/main/java/com/wynnvp/wynncraftvp/config/ConfigFileRecovery.java
+++ b/src/main/java/com/wynnvp/wynncraftvp/config/ConfigFileRecovery.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Team-VoW 2026.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynnvp.wynncraftvp.config;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class ConfigFileRecovery {
+    private static final DateTimeFormatter BACKUP_TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+
+    public static boolean quarantineIfNullByteCorrupted(Path configPath) throws IOException {
+        if (!Files.isRegularFile(configPath)) {
+            return false;
+        }
+
+        byte[] bytes = Files.readAllBytes(configPath);
+        if (!containsNullByte(bytes)) {
+            return false;
+        }
+
+        Files.move(configPath, corruptedConfigPath(configPath), StandardCopyOption.REPLACE_EXISTING);
+        return true;
+    }
+
+    private static boolean containsNullByte(byte[] bytes) {
+        for (byte b : bytes) {
+            if (b == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Path corruptedConfigPath(Path configPath) {
+        String fileName = configPath.getFileName().toString();
+        String timestamp = LocalDateTime.now().format(BACKUP_TIMESTAMP);
+        return configPath.resolveSibling(fileName + ".corrupt-" + timestamp);
+    }
+
+    private ConfigFileRecovery() {}
+}

--- a/src/test/java/com/wynnvp/wynncraftvp/config/ConfigFileRecoveryTest.java
+++ b/src/test/java/com/wynnvp/wynncraftvp/config/ConfigFileRecoveryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © Team-VoW 2026.
+ * This file is released under AGPLv3. See LICENSE for full license details.
+ */
+package com.wynnvp.wynncraftvp.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigFileRecoveryTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void leavesValidConfigInPlace() throws Exception {
+        Path configPath = tempDir.resolve("wynnvp.toml");
+        Files.writeString(configPath, "voiceVolume = 100\n", StandardCharsets.UTF_8);
+
+        assertFalse(ConfigFileRecovery.quarantineIfNullByteCorrupted(configPath));
+
+        assertTrue(Files.exists(configPath));
+        assertEquals("voiceVolume = 100\n", Files.readString(configPath, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void quarantinesConfigContainingNullBytes() throws Exception {
+        Path configPath = tempDir.resolve("wynnvp.toml");
+        Files.write(configPath, new byte[] {0, 0, 0, 0});
+
+        assertTrue(ConfigFileRecovery.quarantineIfNullByteCorrupted(configPath));
+
+        assertFalse(Files.exists(configPath));
+        assertEquals(1, countCorruptConfigs());
+    }
+
+    private long countCorruptConfigs() throws Exception {
+        try (var paths = Files.list(tempDir)) {
+            return paths.filter(path -> path.getFileName().toString().startsWith("wynnvp.toml.corrupt-"))
+                    .count();
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic corrupted configuration file detection and recovery. The mod now automatically identifies corrupted configuration files and safely quarantines them to a timestamped backup location instead of deleting them. This prevents startup failures caused by file corruption and allows users to recover or restore their settings if issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->